### PR TITLE
Add new topic button translation

### DIFF
--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -17,7 +17,7 @@
 				</div>
 
 				<div class="Table-item header-actions hidden-xs">
-					<a href="/compose?cid={category.cid}" component="category/post" id="new_topic" class="btn btn-success" data-ajaxify="false" role="button">Nowy temat</a>
+					<a href="/compose?cid={category.cid}" component="category/post" id="new_topic" class="btn btn-success" data-ajaxify="false" role="button">[[category:new_topic_button]]</a>
 				</div>
 			</div>
 


### PR DESCRIPTION
I noticed that there is a button in the topic template that is not translated and is hard coded.

![image](https://user-images.githubusercontent.com/4021025/52358345-1af04580-2a38-11e9-9cb9-0a7dd515ad79.png)

I've added the `[[category:new_topic_button]]` translation to the `topic.tpl` file.